### PR TITLE
Pin tornado version to <5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,7 @@ tags
 .tags
 /.project
 /.pydevproject
+
+# Eclipse workspace metadata
+.metadata/
+

--- a/odin/http/server.py
+++ b/odin/http/server.py
@@ -39,7 +39,7 @@ class HttpServer(object):
                 access_log.setLevel(level_val)
             except AttributeError:
                 logging.error(
-                    "Access level logging level {} not recognised".format(access_logging)
+                    "Access logging level {} not recognised".format(access_logging)
                 )
 
         # Create an API route

--- a/odin/testing/test_server.py
+++ b/odin/testing/test_server.py
@@ -1,5 +1,5 @@
 import sys
-from __builtin__ import classmethod
+
 if sys.version_info[0] == 3:  # pragma: no cover
     from unittest.mock import Mock
 else:                         # pragma: no cover

--- a/odin/testing/test_server.py
+++ b/odin/testing/test_server.py
@@ -1,4 +1,5 @@
 import sys
+from __builtin__ import classmethod
 if sys.version_info[0] == 3:  # pragma: no cover
     from unittest.mock import Mock
 else:                         # pragma: no cover
@@ -22,7 +23,8 @@ class TestOdinServer(OdinTestServer):
                 'background_task_interval': 0.1,
             }
         }
-        super(TestOdinServer, cls).setup_class(adapter_config)
+        access_logging='debug'
+        super(TestOdinServer, cls).setup_class(adapter_config, access_logging)
 
     @classmethod
     def teardown_class(cls):
@@ -140,6 +142,21 @@ class TestOdinServerMissingAdapters(OdinTestServer):
 
         assert_true(no_adapters_msg_seen)
 
+class TestOdinServerAccessLogging():
+    
+    def test_bad_access_log_level(self):
+        
+        log_capture_filter = LogCaptureFilter()
+        bad_level='wibble'
+        http_server = HttpServer(adapters=[], access_logging=bad_level)
+        
+        msg_seen = False
+        expected_msg = 'Access logging level {} not recognised'.format(bad_level)
+        for msg in log_capture_filter.log_error():
+            if msg == expected_msg:
+                msg_seen = True
+        assert_true(msg_seen)
+        
 class TestOdinHttpServerLogging():
 
     @classmethod

--- a/odin/testing/utils.py
+++ b/odin/testing/utils.py
@@ -60,7 +60,7 @@ class OdinTestServer(object):
     server_conf_file = None
 
     @classmethod
-    def start_server(cls, adapter_config=None):
+    def start_server(cls, adapter_config=None, access_logging=None):
 
         cls.server_conf_file = NamedTemporaryFile(mode='w+')
         parser = SafeConfigParser()
@@ -73,10 +73,14 @@ class OdinTestServer(object):
         parser.set('server', 'http_port', str(cls.server_port))
         parser.set('server', 'http_addr', '127.0.0.1')
         parser.set('server', 'static_path', static_path)
-
+        
         if adapter_config is not None:
             adapters = ', '.join([adapter for adapter in adapter_config])
             parser.set('server', 'adapters', adapters)
+
+        if access_logging is not None:
+            parser.set("server", 'access_logging', 'debug')
+
 
         parser.add_section('tornado')
         parser.set('tornado', 'logging', 'debug')
@@ -108,10 +112,10 @@ class OdinTestServer(object):
             cls.server_conf_file = None
 
     @classmethod
-    def setup_class(cls, adapter_config=None):
+    def setup_class(cls, adapter_config=None, access_logging=None):
         if cls.launch_server:
             cls.log_capture_filter = LogCaptureFilter()
-            cls.start_server(adapter_config)
+            cls.start_server(adapter_config, access_logging)
             time.sleep(0.2)
 
     @classmethod

--- a/odin/testing/utils.py
+++ b/odin/testing/utils.py
@@ -81,7 +81,6 @@ class OdinTestServer(object):
         if access_logging is not None:
             parser.set("server", 'access_logging', 'debug')
 
-
         parser.add_section('tornado')
         parser.set('tornado', 'logging', 'debug')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ coverage==4.1b2
 codeclimate-test-reporter>=0.1.0
 pyzmq>=15.2.0
 requests>=2.9.1
-tornado>=4.3
+tornado>=4.3,<5.0
 future


### PR DESCRIPTION
This PR pins the requirement for tornado to <5, to avoid issues with installation and hanging test runs. Also minor modifications to some tests to complete coverage of recent access logging changes.