### PR TITLE
Make handling of trailing slashes in adapter URLs consistent

### DIFF
--- a/odin/adapters/parameter_tree.py
+++ b/odin/adapters/parameter_tree.py
@@ -97,14 +97,17 @@ class ParameterTree(object):
         :param path: path in tree to get parameter values for
         :returns: dict of parameter tree at the specified path
         """
-        # Split the path by levels
+
+        # Split the path by levels, truncating the last level if path ends in trailing slash
         levels = path.split('/')
+        if levels[-1] == '':
+             del levels[-1]
 
         # Initialise the subtree before descent
         subtree = self.__tree
 
         # If this is single level path, return the populated tree at the top level
-        if levels == ['']:
+        if len(levels) == 0:
             return self.__recursive_populate_tree(subtree)
 
         # Descend the specified levels in the path, checking for a valid subtree

--- a/odin/http/routes/api.py
+++ b/odin/http/routes/api.py
@@ -130,12 +130,11 @@ class ApiHandler(tornado.web.RequestHandler):
         :param subsystem: subsystem element of URI, defining adapter to be called
         :param path: remaining URI path to be passed to adapter method
         """
-        print("ApiHandler.get path", path)
         response = self.route.adapter(subsystem).get(path, self.request)
         self.respond(response)
 
     @validate_api_request(_api_version)
-    def put(self, subsystem, path):
+    def put(self, subsystem, path=''):
         """Handle an API PUT request.
 
         :param subsystem: subsystem element of URI, defining adapter to be called
@@ -145,7 +144,7 @@ class ApiHandler(tornado.web.RequestHandler):
         self.respond(response)
 
     @validate_api_request(_api_version)
-    def delete(self, subsystem, path):
+    def delete(self, subsystem, path=''):
         """Handle an API DELETE request.
 
         :param subsystem: subsystem element of URI, defining adapter to be called

--- a/odin/http/routes/api.py
+++ b/odin/http/routes/api.py
@@ -193,7 +193,9 @@ class ApiRoute(Route):
         # enforced by the validate_api_request decorator, is the following:
         #
         #    /api/<version>/<subsystem>/<action>....
-
+        #
+        # The second pattern allows an API adapter to be accessed with or without
+        # a trailing slash for maximum compatibility
         self.add_handler((r"/api/(.*?)/(.*?)/(.*)", ApiHandler, dict(route=self)))
         self.add_handler((r"/api/(.*?)/(.*?)/?", ApiHandler, dict(route=self)))
 

--- a/odin/http/routes/api.py
+++ b/odin/http/routes/api.py
@@ -124,12 +124,13 @@ class ApiHandler(tornado.web.RequestHandler):
         self.route = route
 
     @validate_api_request(_api_version)
-    def get(self, subsystem, path):
+    def get(self, subsystem, path=''):
         """Handle an API GET request.
 
         :param subsystem: subsystem element of URI, defining adapter to be called
         :param path: remaining URI path to be passed to adapter method
         """
+        print("ApiHandler.get path", path)
         response = self.route.adapter(subsystem).get(path, self.request)
         self.respond(response)
 
@@ -195,6 +196,7 @@ class ApiRoute(Route):
         #    /api/<version>/<subsystem>/<action>....
 
         self.add_handler((r"/api/(.*?)/(.*?)/(.*)", ApiHandler, dict(route=self)))
+        self.add_handler((r"/api/(.*?)/(.*?)/?", ApiHandler, dict(route=self)))
 
         self.adapters = {}
 

--- a/odin/testing/adapters/test_parameter_tree.py
+++ b/odin/testing/adapters/test_parameter_tree.py
@@ -107,6 +107,11 @@ class TestParameterTree():
         branch_vals = self.nested_tree.get('branch')
         assert_equals(branch_vals['branch'], self.nested_dict['branch'])
 
+    def test_nested_tree_trailing_slash(self):
+
+        branch_vals = self.nested_tree.get('branch/')
+        assert_equals(branch_vals['branch'], self.nested_dict['branch'])
+
     def test_callback_modifies_branch_value(self):
 
         branch_data = deepcopy(self.nested_dict['branch'])
@@ -273,3 +278,21 @@ class TestRwParameterTree():
         new_float_value = self.nested_rw_param + 2.3456
         self.rw_callable_tree.set('branch/nestedRwParam', new_float_value)
         assert_equal(self.nested_rw_param, new_float_value)
+
+    def test_rw_callable_nested_tree_set(self):
+
+        nested_branch = self.rw_callable_tree.get('branch')['branch']
+        new_rw_param_val = 45.876
+        nested_branch['nestedRwParam'] = new_rw_param_val
+        self.rw_callable_tree.set('branch', nested_branch)
+        new_branch = self.rw_callable_tree.get('branch')['branch']
+        assert_equal(new_branch['nestedRwParam'], new_rw_param_val)
+
+    def test_rw_callable_nested_tree_set_trailing_slash(self):
+
+        nested_branch = self.rw_callable_tree.get('branch/')['branch']
+        new_rw_param_val = 24.601
+        nested_branch['nestedRwParam'] = new_rw_param_val
+        self.rw_callable_tree.set('branch', nested_branch)
+        new_branch = self.rw_callable_tree.get('branch/')['branch']
+        assert_equal(new_branch['nestedRwParam'], new_rw_param_val)

--- a/odin/testing/test_server.py
+++ b/odin/testing/test_server.py
@@ -34,6 +34,14 @@ class TestOdinServer(OdinTestServer):
         result = requests.get(self.build_url('dummy/config/none'))
         assert_equal(result.status_code, 200)
 
+    def test_adapter_get_trailing_slash(self):
+        result = requests.get(self.build_url('dummy/'))
+        assert_equal(result.status_code, 200)
+
+    def test_adapter_get_no_trailing_slash(self):
+        result = requests.get(self.build_url('dummy'))
+        assert_equal(result.status_code, 200)
+
     def test_simple_client_put(self):
         headers = {'Content-Type' : 'application/json'}
         payload = {'some': 'data'}


### PR DESCRIPTION
This PR makes the handling of URLs with and without trailing slash characters consistent between the ApiAdapter and ParameterTree elements of odin-control. This makes the following example URLs be handlded consistently and return without errors:

* ```/api/0.1/demo_adapter```
* ```/api/0.1/demo_adapter/```

(i.e. return the entire parameter tree for an adapter), and

* ```/api/0.1/demo_adapter/node```
* ```/api/0.1/demo_adapter/node/```

(i.e. return a subtree within the adapter parameter tree). 

Previously, these were handled inconsistently and only one of each type worked correctly. **Note** there is a pedantic argument for formally-correct REST APIs about the difference between the two, which we do not support in the REST-like API mechanism implemented in odin-control - both are considered equivalent.

This PR is a precursor to the planned proxy adapter and parameter metadata support.