### PR TITLE
Make API version handler report correct key

### DIFF
--- a/odin/http/routes/api.py
+++ b/odin/http/routes/api.py
@@ -67,7 +67,7 @@ class ApiVersionHandler(tornado.web.RequestHandler):
             self.write('Requested content types not supported')
             return
 
-        self.write(json.dumps({'api_version': _api_version}))
+        self.write(json.dumps({'api': _api_version}))
 
 
 class ApiAdapterListHandler(tornado.web.RequestHandler):

--- a/odin/testing/static/js/odin_server.js
+++ b/odin/testing/static/js/odin_server.js
@@ -9,8 +9,8 @@ $( document ).ready(function() {
 function update_api_version() {
 
     $.getJSON('/api', function(response) {
-        $('#api-version').html(response.api_version);
-        api_version = response.api_version;
+        api_version = response.api;
+        $('#api-version').html(api_version);
     });
 }
 

--- a/odin/testing/test_server.py
+++ b/odin/testing/test_server.py
@@ -77,7 +77,7 @@ class TestOdinServer(OdinTestServer):
             headers=headers
         )
         assert_equal(result.status_code, 200)
-        assert_equal(result.json()['api_version'], 0.1)
+        assert_equal(result.json()['api'], 0.1)
 
     def test_api_version_bad_accept(self):
         headers = {'Accept': 'text/plain'}


### PR DESCRIPTION
Requests to /api to determine the API version supported now return a matching key ('api' rather than 'api_version').

Closes #33