### PR TITLE
Mutable tree

### DIFF
--- a/src/odin/adapters/parameter_tree.py
+++ b/src/odin/adapters/parameter_tree.py
@@ -467,8 +467,13 @@ class ParameterTree(object):
         # Recurse down tree if this is a branch node
         if isinstance(node, dict) and isinstance(new_data, dict):
             try:
-                node.update({k: self.__recursive_merge_tree(
-                    node[k], v, cur_path + k + '/') for k, v in self.__remove_metadata(new_data)})
+                update = {}
+                for k, v in self.__remove_metadata(new_data):
+                    mutable = self.mutable or any(cur_path.startswith(part) for part in self.mutable_paths)
+                    if mutable and k not in node:
+                        node[k] = {}
+                    update[k] = self.__recursive_merge_tree(node[k], v, cur_path + k + '/')
+                    node.update(update)
                 return node
             except KeyError as key_error:
                 raise ParameterTreeError(

--- a/src/odin/adapters/parameter_tree.py
+++ b/src/odin/adapters/parameter_tree.py
@@ -205,6 +205,7 @@ class ParameterTree(object):
           description - A printable description for that branch of the tree
 
         :param tree: dict representing the parameter tree
+        :param mutable: Flag, setting the tree 
         """
 
         # Recursively check and initialise the tree
@@ -313,6 +314,14 @@ class ParameterTree(object):
             merge_parent[int(levels[-1])] = merged
 
     def delete(self, path=''):
+        """
+        Remove Parameters from a Mutable Tree.
+
+        This method deletes selected parameters from a tree, if that tree has been flagged as
+        Mutable. Deletion of Branch Nodes means all child nodes of that Branch Node are also deleted
+
+        :param path: Path to selected Parameter Node in the tree
+        """
         if not self.mutable:
             raise ParameterTreeError("Invalid Delete Attempt: Tree Not Mutable")
         
@@ -478,7 +487,7 @@ class ParameterTree(object):
             node.set(new_data)
         else:
             # Validate type of new node matches existing
-            if not self.mutable and type(node) is not type(new_data):  # this mutable flags feels a bit like a sledgehammer
+            if not self.mutable and type(node) is not type(new_data):
                 raise ParameterTreeError('Type mismatch updating {}: got {} expected {}'.format(
                     cur_path[:-1], type(new_data).__name__, type(node).__name__
                 ))

--- a/src/odin/adapters/parameter_tree.py
+++ b/src/odin/adapters/parameter_tree.py
@@ -338,11 +338,14 @@ class ParameterTree(object):
             subtree.clear()
             return
         try:
+            # navigate down the path, based on hwo path navigation works in the Set Method above
             for level in levels[:-1]:
+                # if dict, subtree is normal branch, continue navigation
                 if isinstance(subtree, dict):
                     subtree = subtree[level]
-                else:
+                else:  # if not a dict, but still navigating, it should be a list, so next path is int
                     subtree = subtree[int(level)]
+            # once we are at the second to last part of the path, we want to delete whatever comes next
             if isinstance(subtree, list):
                 subtree.pop(int(levels[-1]))
             else:

--- a/src/odin/adapters/parameter_tree.py
+++ b/src/odin/adapters/parameter_tree.py
@@ -337,17 +337,17 @@ class ParameterTree(object):
             for key in subtree.copy():  # copy to avoid runtime error
                 subtree.pop(key)
             return
-
-        for level in levels[:-1]:
-            try:
+        try:
+            for level in levels[:-1]:
                 if isinstance(subtree, dict):
                     subtree = subtree[level]
                 else:
                     subtree = subtree[int(level)]
-            except (KeyError, ValueError, IndexError):
-                raise ParameterTreeError("Invalid path: {}".format(path))
+            subtree.pop(levels[-1])
+        except (KeyError, ValueError, IndexError):
+            raise ParameterTreeError("Invalid path: {}".format(path))
         
-        subtree.pop(levels[-1])
+
 
 
     def __recursive_build_tree(self, node, path=''):

--- a/src/odin/adapters/parameter_tree.py
+++ b/src/odin/adapters/parameter_tree.py
@@ -180,7 +180,7 @@ class ParameterTree(object):
 
     METADATA_FIELDS = ["name", "description"]
 
-    def __init__(self, tree):
+    def __init__(self, tree, mutable=False):
         """Initialise the ParameterTree object.
 
         This constructor recursively initialises the ParameterTree object, based on the parameter
@@ -212,6 +212,8 @@ class ParameterTree(object):
 
         # Recursively check and initialise the tree
         self._tree = self.__recursive_build_tree(tree)
+        # Flag, if set to true, allows nodes to be replaced and new nodes created
+        self.mutable = mutable
 
     @property
     def callbacks(self):
@@ -321,23 +323,23 @@ class ParameterTree(object):
         else:
             merge_parent[int(levels[-1])] = merged
 
-    def add_callback(self, path, callback):
-        """Add a callback to a given path in the tree - DEPRECATED.
+    # def add_callback(self, path, callback):
+    #     """Add a callback to a given path in the tree - DEPRECATED.
 
-        This now deprecated method adds a callback to the specified path in the
-        tree. Originally intended to allow set() calls to update values in the
-        underlying object or device represented by the tree, this has been
-        replaced by the symmetric read/write ParameterAccessor mechanism. Its
-        remaining function could be to allow side-effects during set() calls.
+    #     This now deprecated method adds a callback to the specified path in the
+    #     tree. Originally intended to allow set() calls to update values in the
+    #     underlying object or device represented by the tree, this has been
+    #     replaced by the symmetric read/write ParameterAccessor mechanism. Its
+    #     remaining function could be to allow side-effects during set() calls.
 
-        :param path: path to add callback for
-        :param callback: method to be called when the appropriate set() call is made
-        """
-        warnings.warn(
-            "Callbacks in parameter trees are deprecated, use parameter accessors instead",
-            DeprecationWarning
-        )
-        self._callbacks.append([path, callback])
+    #     :param path: path to add callback for
+    #     :param callback: method to be called when the appropriate set() call is made
+    #     """
+    #     warnings.warn(
+    #         "Callbacks in parameter trees are deprecated, use parameter accessors instead",
+    #         DeprecationWarning
+    #     )
+    #     self._callbacks.append([path, callback])
 
     def __recursive_build_tree(self, node, path=''):
         """Recursively build and expand out a tree or node.
@@ -452,7 +454,7 @@ class ParameterTree(object):
 
         :param node: tree node to populate and return
         :param new_data: dict of new data to be merged in at this path in the tree
-        :param cur_path: current oath in the tree
+        :param cur_path: current path in the tree
         :returns: the update node at this point in the tree
         """
         # Recurse down tree if this is a branch node
@@ -481,7 +483,7 @@ class ParameterTree(object):
             node.set(new_data)
         else:
             # Validate type of new node matches existing
-            if type(node) is not type(new_data):
+            if not self.mutable and type(node) is not type(new_data):  # this mutable flags feels a bit like a sledgehammer
                 raise ParameterTreeError('Type mismatch updating {}: got {} expected {}'.format(
                     cur_path[:-1], type(new_data).__name__, type(node).__name__
                 ))

--- a/src/odin/adapters/parameter_tree.py
+++ b/src/odin/adapters/parameter_tree.py
@@ -324,9 +324,9 @@ class ParameterTree(object):
 
         :param path: Path to selected Parameter Node in the tree
         """
-        if not self.mutable:
+        if not self.mutable and not any(path.startswith(part) for part in self.mutable_paths):
             raise ParameterTreeError("Invalid Delete Attempt: Tree Not Mutable")
-        
+
         # Split the path by levels, truncating the last level if path ends in trailing slash
         levels = path.split('/')
         if levels[-1] == '':

--- a/tests/adapters/test_parameter_tree.py
+++ b/tests/adapters/test_parameter_tree.py
@@ -781,7 +781,8 @@ class ParameterTreeMutableTestFixture():
                     'nested_val': 125,
                     'dont_touch': "let me stay!",
                     'write': (self.get_write, self.set_write)
-                }
+                },
+                'list': [1, 2, 3, 4]
             },
             'read': (self.get_read,)
         }
@@ -851,7 +852,7 @@ class TestParamTreeMutable():
         test_tree_mutable.param_tree.set(path, new_node)
         val = test_tree_mutable.param_tree.get(path)
         # logging.debug(test_tree_mutable.param_tree.get(""))
-        assert val[path] == new_node
+        assert val[path]['double_nest'] == new_node['double_nest']
 
     def test_mutable_put_merge_nested_path(self, test_tree_mutable):
 
@@ -894,10 +895,19 @@ class TestParamTreeMutable():
 
         assert "Invalid Delete Attempt" in str(excinfo.value)
 
-    def test_mutable_detele_entire_tree(self, test_tree_mutable):
+    def test_mutable_delete_entire_tree(self, test_tree_mutable):
 
         path = ''
 
         test_tree_mutable.param_tree.delete(path)
         val = test_tree_mutable.param_tree.get(path)
         assert not val
+
+    def test_mutable_delete_invalid_path(self, test_tree_mutable):
+
+        path = 'nest/not_real'
+
+        with pytest.raises(ParameterTreeError) as excinfo:
+            test_tree_mutable.param_tree.delete(path)
+
+        assert "Invalid path" in str(excinfo.value)

--- a/tests/adapters/test_parameter_tree.py
+++ b/tests/adapters/test_parameter_tree.py
@@ -278,10 +278,10 @@ class ParameterTreeTestFixture(object):
     def get_accessor_param(self):
         return self.accessor_params
 
-    def branch_callback(self, path, value):
-        self.branch_callback_count += 1
-        # print("branch_callback call #{}: on path {} with value {}".format(
-        #     self.branch_callback_count, path, value))
+    # def branch_callback(self, path, value):
+    #     self.branch_callback_count += 1
+    #     # print("branch_callback call #{}: on path {} with value {}".format(
+    #     #     self.branch_callback_count, path, value))
 
     def setup(self):
         TestParameterTree.branch_callback_count = 0
@@ -337,6 +337,18 @@ class TestParameterTree():
         """Test that getting a tree with trailing slash returns the correct dict."""
         branch_vals = test_param_tree.nested_tree.get('branch/')
         assert branch_vals['branch'] == test_param_tree.nested_dict['branch']
+
+    def test_callback_with_extra_branch_paths(self, test_param_tree):
+        """
+        Test that modifiying a branch in a callback tree with extra parameters raises an error.
+        """
+        branch_data = deepcopy(test_param_tree.nested_dict['branch'])
+        branch_data['extraParam'] = 'oops'
+
+        with pytest.raises(ParameterTreeError) as excinfo:
+            test_param_tree.complex_tree.set('branch', branch_data)
+
+        assert 'Invalid path' in str(excinfo.value)
 
     def test_complex_tree_calls_leaf_nodes(self, test_param_tree):
         """

--- a/tests/adapters/test_parameter_tree.py
+++ b/tests/adapters/test_parameter_tree.py
@@ -902,3 +902,34 @@ class TestParamTreeMutable():
         # logging.debug(test_tree_mutable.param_tree.get(""))
         assert val[path]['double_nest']['nested_val'] == new_node['double_nest']['nested_val']
         assert 'dont_touch' in val[path]['double_nest']
+
+    def test_mutable_delete_method(self, test_tree_mutable):
+
+        path = 'nest/double_nest'
+
+        test_tree_mutable.param_tree.delete(path)
+        tree = test_tree_mutable.param_tree.get('')
+        # logging.debug(tree)
+        assert 'double_nest' not in tree['nest']
+        with pytest.raises(ParameterTreeError) as excinfo:
+            test_tree_mutable.param_tree.get(path)
+
+        assert "Invalid path" in str(excinfo.value)
+
+    def test_mutable_delete_immutable_tree(self, test_tree_mutable):
+
+        test_tree_mutable.param_tree.mutable = False
+
+        with pytest.raises(ParameterTreeError) as excinfo:
+            path = 'nest/double_nest'
+            test_tree_mutable.param_tree.delete(path)
+
+        assert "Invalid Delete Attempt" in str(excinfo.value)
+
+    def test_mutable_detele_entire_tree(self, test_tree_mutable):
+
+        path = ''
+
+        test_tree_mutable.param_tree.delete(path)
+        val = test_tree_mutable.param_tree.get(path)
+        assert not val

--- a/tests/adapters/test_parameter_tree.py
+++ b/tests/adapters/test_parameter_tree.py
@@ -6,7 +6,6 @@ Tim Nicholls, STFC Application Engingeering
 from copy import deepcopy
 
 import pytest
-import logging  # dont leave this here
 
 from odin.adapters.parameter_tree import ParameterAccessor, ParameterTree, ParameterTreeError
 
@@ -863,7 +862,6 @@ class TestParamTreeMutable():
 
         test_tree_mutable.param_tree.set(path, new_node)
         val = test_tree_mutable.param_tree.get(path)
-        # logging.debug(test_tree_mutable.param_tree.get(""))
         assert val[path]['double_nest'] == new_node['double_nest']
 
     def test_mutable_put_merge_nested_path(self, test_tree_mutable):
@@ -880,7 +878,6 @@ class TestParamTreeMutable():
 
         test_tree_mutable.param_tree.set(path, new_node)
         val = test_tree_mutable.param_tree.get(path)
-        # logging.debug(test_tree_mutable.param_tree.get(""))
         assert val[path]['double_nest']['nested_val'] == new_node['double_nest']['nested_val']
         assert 'dont_touch' in val[path]['double_nest']
 
@@ -890,7 +887,6 @@ class TestParamTreeMutable():
 
         test_tree_mutable.param_tree.delete(path)
         tree = test_tree_mutable.param_tree.get('')
-        # logging.debug(tree)
         assert 'double_nest' not in tree['nest']
         with pytest.raises(ParameterTreeError) as excinfo:
             test_tree_mutable.param_tree.get(path)
@@ -929,7 +925,6 @@ class TestParamTreeMutable():
         path = 'nest/list/3'
 
         test_tree_mutable.param_tree.delete(path)
-        logging.debug(test_tree_mutable.param_tree.tree)
         val = test_tree_mutable.param_tree.get('nest/list')
         assert '3' not in val['list']
 
@@ -937,6 +932,5 @@ class TestParamTreeMutable():
         path = 'nest/list/2/list_test'
 
         test_tree_mutable.param_tree.delete(path)
-        logging.debug(test_tree_mutable.param_tree.tree)
         val = test_tree_mutable.param_tree.get('nest/list')
         assert {'list_test': "test"} not in val['list']

--- a/tests/adapters/test_parameter_tree.py
+++ b/tests/adapters/test_parameter_tree.py
@@ -6,6 +6,7 @@ Tim Nicholls, STFC Application Engingeering
 from copy import deepcopy
 
 import pytest
+import logging  # dont leave this here
 
 from odin.adapters.parameter_tree import ParameterAccessor, ParameterTree, ParameterTreeError
 
@@ -247,13 +248,13 @@ class ParameterTreeTestFixture(object):
         }
         self.nested_tree = ParameterTree(self.nested_dict)
 
-        self.callback_tree = deepcopy(self.nested_tree)
-        self.callback_tree.add_callback('branch/', self.branch_callback)
+        # self.callback_tree = deepcopy(self.nested_tree)
+        # self.callback_tree.add_callback('branch/', self.branch_callback)
 
-        self.branch_callback_count = 0
+        # self.branch_callback_count = 0
 
         self.complex_tree_branch = ParameterTree(deepcopy(self.nested_dict))
-        self.complex_tree_branch.add_callback('', self.branch_callback)
+        # self.complex_tree_branch.add_callback('', self.branch_callback)
 
         self.complex_tree = ParameterTree({
             'intParam': self.int_value,
@@ -337,36 +338,36 @@ class TestParameterTree():
         branch_vals = test_param_tree.nested_tree.get('branch/')
         assert branch_vals['branch'] == test_param_tree.nested_dict['branch']
 
-    def test_callback_modifies_branch_value(self, test_param_tree):
-        """Test that the modifying a branch below a callback does change the branch."""
-        branch_data = deepcopy(test_param_tree.nested_dict['branch'])
-        branch_data['branchIntParam'] = 90210
+    # def test_callback_modifies_branch_value(self, test_param_tree):
+    #     """Test that the modifying a branch below a callback does change the branch."""
+    #     branch_data = deepcopy(test_param_tree.nested_dict['branch'])
+    #     branch_data['branchIntParam'] = 90210
 
-        test_param_tree.callback_tree.set('branch', branch_data)
+    #     test_param_tree.callback_tree.set('branch', branch_data)
 
-        modified_branch_vals = test_param_tree.callback_tree.get('branch')
-        assert modified_branch_vals['branch'] == branch_data
-        assert test_param_tree.branch_callback_count == len(branch_data)
+    #     modified_branch_vals = test_param_tree.callback_tree.get('branch')
+    #     assert modified_branch_vals['branch'] == branch_data
+    #     assert test_param_tree.branch_callback_count == len(branch_data)
 
-    def test_callback_modifies_single_branch_value(self, test_param_tree):
-        """Test that modifying a single branch value below a callback works correctly."""
-        int_param = 22603
-        test_param_tree.callback_tree.set('branch/branchIntParam', int_param)
+    # def test_callback_modifies_single_branch_value(self, test_param_tree):
+    #     """Test that modifying a single branch value below a callback works correctly."""
+    #     int_param = 22603
+    #     test_param_tree.callback_tree.set('branch/branchIntParam', int_param)
 
-        val = test_param_tree.callback_tree.get('branch/branchIntParam')
-        assert val['branchIntParam'] == int_param
+    #     val = test_param_tree.callback_tree.get('branch/branchIntParam')
+    #     assert val['branchIntParam'] == int_param
 
-    def test_callback_with_extra_branch_paths(self, test_param_tree):
-        """
-        Test that modifiying a branch in a callback tree with extra parameters raises an error.
-        """
-        branch_data = deepcopy(test_param_tree.nested_dict['branch'])
-        branch_data['extraParam'] = 'oops'
+    # def test_callback_with_extra_branch_paths(self, test_param_tree):
+    #     """
+    #     Test that modifiying a branch in a callback tree with extra parameters raises an error.
+    #     """
+    #     branch_data = deepcopy(test_param_tree.nested_dict['branch'])
+    #     branch_data['extraParam'] = 'oops'
 
-        with pytest.raises(ParameterTreeError) as excinfo:
-            test_param_tree.callback_tree.set('branch', branch_data)
+    #     with pytest.raises(ParameterTreeError) as excinfo:
+    #         test_param_tree.callback_tree.set('branch', branch_data)
 
-        assert 'Invalid path' in str(excinfo.value)
+    #     assert 'Invalid path' in str(excinfo.value)
 
     def test_complex_tree_calls_leaf_nodes(self, test_param_tree):
         """
@@ -458,16 +459,16 @@ class TestParameterTree():
     def test_list_tree_set_from_root(self, test_param_tree):
         """Test that it is possible to set a list tree from its root."""
         tree_data = {
-    	    'main' : [
+            'main' : [
                 {
                     'intParam': 0,
                     'floatParam': 0.00,
                     'boolParam': False,
                     'strParam':  "test",
                 },
-		        [1,2,3,4]
+                [1,2,3,4]
             ]
-	    }
+        }
 
         test_param_tree.list_tree.set("",tree_data)
         assert test_param_tree.list_tree.get("main") == tree_data
@@ -794,3 +795,110 @@ class TestParameterTreeMetadata():
         assert "{} is above the maximum value {} for {}".format(
                 high_value, test_tree_metadata.int_rw_param_metadata["max"], 
                 "intCallableRwParam") in str(excinfo.value)
+
+
+class ParameterTreeMutableTestFixture():
+
+    def __init__(self):
+        # param tree thats set to mutable, with some nodes i guess?
+        # make sure to test the different types of node being added/overwritten (inc param-accessor)
+        self.read_value = 64
+        self.write_value = "test"
+
+        self.param_tree_dict = {
+            'extra': 'wibble',
+            'bonus': 'win',
+            'nest': {
+                'double_nest': {
+                    'nested_val': 125,
+                    'dont_touch': "let me stay!",
+                    'write': (self.get_write, self.set_write)
+                }
+            },
+            'read': (self.get_read,)
+        }
+
+        self.param_tree = ParameterTree(self.param_tree_dict)
+        self.param_tree.mutable = True
+
+    def get_read(self):
+        return self.read_value
+
+    def get_write(self):
+        return self.write_value
+
+    def set_write(self, data):
+        self.write_value = data
+
+@pytest.fixture()
+def test_tree_mutable():
+    """Test fixture for use in testing parameter tree metadata."""
+    test_tree_mutable = ParameterTreeMutableTestFixture()
+    yield test_tree_mutable
+
+
+class TestParamTreeMutable():
+    """Class to test the behaviour of the Mutable flag for Param Tree"""
+
+    def test_mutable_put_differnt_data_type(self, test_tree_mutable):
+
+        new_data = 75
+        test_tree_mutable.param_tree.set('bonus', new_data)
+        val = test_tree_mutable.param_tree.get('bonus')
+        assert val['bonus'] == new_data
+
+    def test_mutable_put_new_branch_node(self, test_tree_mutable):
+
+        new_node = {"new": 65}
+        test_tree_mutable.param_tree.set('extra', new_node)
+
+        val = test_tree_mutable.param_tree.get('extra')
+        assert val['extra'] == new_node
+
+    def test_mutable_put_overwrite_param_accessor_read_only(self, test_tree_mutable):
+
+        new_node = {"Node": "Broke Accessor"}
+        with pytest.raises(ParameterTreeError) as excinfo:
+            test_tree_mutable.param_tree.set('read', new_node)
+        
+        assert "is read-only" in str(excinfo.value)
+
+    def test_mutable_put_overwrite_param_accessor_read_write(self, test_tree_mutable):
+
+        new_node = {"Node": "Broke Accessor"}
+        path = 'nest/double_nest/write'
+
+        with pytest.raises(ParameterTreeError) as excinfo:
+            test_tree_mutable.param_tree.set(path, new_node)
+
+        assert "Type mismatch setting" in str(excinfo.value)
+        # val = test_tree_mutable.param_tree.get(path)
+        # assert val['write'] == new_node
+
+    def test_mutable_put_replace_nested_path(self, test_tree_mutable):
+
+        new_node = {"double_nest": 294}
+        path = 'nest'
+
+        test_tree_mutable.param_tree.set(path, new_node)
+        val = test_tree_mutable.param_tree.get(path)
+        # logging.debug(test_tree_mutable.param_tree.get(""))
+        assert val[path] == new_node
+
+    def test_mutable_put_merge_nested_path(self, test_tree_mutable):
+
+        new_node = {
+            "double_nest": {
+                'nested_val': {
+                    "additional_val": "New value Here!",
+                    "add_int": 648
+                }
+            }
+        }
+        path = 'nest'
+
+        test_tree_mutable.param_tree.set(path, new_node)
+        val = test_tree_mutable.param_tree.get(path)
+        # logging.debug(test_tree_mutable.param_tree.get(""))
+        assert val[path]['double_nest']['nested_val'] == new_node['double_nest']['nested_val']
+        assert 'dont_touch' in val[path]['double_nest']

--- a/tests/adapters/test_parameter_tree.py
+++ b/tests/adapters/test_parameter_tree.py
@@ -782,7 +782,7 @@ class ParameterTreeMutableTestFixture():
                     'dont_touch': "let me stay!",
                     'write': (self.get_write, self.set_write)
                 },
-                'list': [1, 2, 3, 4]
+                'list': [0, 1, {'list_test': "test"}, 3]
             },
             'read': (self.get_read,)
         }
@@ -911,3 +911,20 @@ class TestParamTreeMutable():
             test_tree_mutable.param_tree.delete(path)
 
         assert "Invalid path" in str(excinfo.value)
+
+    def test_mutable_delete_from_list(self, test_tree_mutable):
+
+        path = 'nest/list/3'
+
+        test_tree_mutable.param_tree.delete(path)
+        logging.debug(test_tree_mutable.param_tree.tree)
+        val = test_tree_mutable.param_tree.get('nest/list')
+        assert '3' not in val['list']
+
+    def test_mustable_delete_from_dict_in_list(self, test_tree_mutable):
+        path = 'nest/list/2/list_test'
+
+        test_tree_mutable.param_tree.delete(path)
+        logging.debug(test_tree_mutable.param_tree.tree)
+        val = test_tree_mutable.param_tree.get('nest/list')
+        assert {'list_test': "test"} not in val['list']

--- a/tests/adapters/test_parameter_tree.py
+++ b/tests/adapters/test_parameter_tree.py
@@ -784,7 +784,8 @@ class ParameterTreeMutableTestFixture():
                 },
                 'list': [0, 1, {'list_test': "test"}, 3]
             },
-            'read': (self.get_read,)
+            'read': (self.get_read,),
+            'empty': {}
         }
 
         self.param_tree = ParameterTree(self.param_tree_dict)
@@ -823,6 +824,15 @@ class TestParamTreeMutable():
 
         val = test_tree_mutable.param_tree.get('extra')
         assert val['extra'] == new_node
+
+    def test_mutable_put_new_sibling_node(self, test_tree_mutable):
+
+        new_node = {'new': 65}
+        path = 'nest'
+
+        test_tree_mutable.param_tree.set(path, new_node)
+        val = test_tree_mutable.param_tree.get(path)
+        assert 'new' in val[path]
 
     def test_mutable_put_overwrite_param_accessor_read_only(self, test_tree_mutable):
 
@@ -987,3 +997,11 @@ class TestParamTreeMutable():
             new_tree.set(path, new_node)
 
         assert "Type mismatch" in str(excinfo.value)
+
+    def test_mutable_add_to_empty_dict(self, test_tree_mutable):
+
+        new_node = {"new": 65}
+        path = 'empty'
+        test_tree_mutable.param_tree.set(path, new_node)
+        val = test_tree_mutable.param_tree.get(path)
+        assert val[path] == new_node

--- a/tests/adapters/test_parameter_tree.py
+++ b/tests/adapters/test_parameter_tree.py
@@ -928,11 +928,13 @@ class TestParamTreeMutable():
 
         new_tree = ParameterTree({
             'immutable_param': "Hello",
-            "tree": test_tree_mutable.param_tree
+            "nest": {
+                "tree": test_tree_mutable.param_tree
+            }
         })
 
         new_node = {"new": 65}
-        path = 'tree/extra'
+        path = 'nest/tree/extra'
         new_tree.set(path, new_node)
         val = new_tree.get(path)
         assert val['extra'] == new_node

--- a/tests/adapters/test_parameter_tree.py
+++ b/tests/adapters/test_parameter_tree.py
@@ -338,37 +338,6 @@ class TestParameterTree():
         branch_vals = test_param_tree.nested_tree.get('branch/')
         assert branch_vals['branch'] == test_param_tree.nested_dict['branch']
 
-    # def test_callback_modifies_branch_value(self, test_param_tree):
-    #     """Test that the modifying a branch below a callback does change the branch."""
-    #     branch_data = deepcopy(test_param_tree.nested_dict['branch'])
-    #     branch_data['branchIntParam'] = 90210
-
-    #     test_param_tree.callback_tree.set('branch', branch_data)
-
-    #     modified_branch_vals = test_param_tree.callback_tree.get('branch')
-    #     assert modified_branch_vals['branch'] == branch_data
-    #     assert test_param_tree.branch_callback_count == len(branch_data)
-
-    # def test_callback_modifies_single_branch_value(self, test_param_tree):
-    #     """Test that modifying a single branch value below a callback works correctly."""
-    #     int_param = 22603
-    #     test_param_tree.callback_tree.set('branch/branchIntParam', int_param)
-
-    #     val = test_param_tree.callback_tree.get('branch/branchIntParam')
-    #     assert val['branchIntParam'] == int_param
-
-    # def test_callback_with_extra_branch_paths(self, test_param_tree):
-    #     """
-    #     Test that modifiying a branch in a callback tree with extra parameters raises an error.
-    #     """
-    #     branch_data = deepcopy(test_param_tree.nested_dict['branch'])
-    #     branch_data['extraParam'] = 'oops'
-
-    #     with pytest.raises(ParameterTreeError) as excinfo:
-    #         test_param_tree.callback_tree.set('branch', branch_data)
-
-    #     assert 'Invalid path' in str(excinfo.value)
-
     def test_complex_tree_calls_leaf_nodes(self, test_param_tree):
         """
         Test that accessing valyus in a complex tree returns the correct values for 
@@ -781,7 +750,6 @@ class TestParameterTreeMetadata():
         assert "{} is below the minimum value {} for {}".format(
                 low_value, test_tree_metadata.int_rw_param_metadata["min"], 
                 "intCallableRwParam") in str(excinfo.value)
-        
 
     def test_rw_param_above_max_value(self, test_tree_metadata):
         """

--- a/tests/adapters/test_parameter_tree.py
+++ b/tests/adapters/test_parameter_tree.py
@@ -247,13 +247,7 @@ class ParameterTreeTestFixture(object):
         }
         self.nested_tree = ParameterTree(self.nested_dict)
 
-        # self.callback_tree = deepcopy(self.nested_tree)
-        # self.callback_tree.add_callback('branch/', self.branch_callback)
-
-        # self.branch_callback_count = 0
-
         self.complex_tree_branch = ParameterTree(deepcopy(self.nested_dict))
-        # self.complex_tree_branch.add_callback('', self.branch_callback)
 
         self.complex_tree = ParameterTree({
             'intParam': self.int_value,
@@ -277,13 +271,7 @@ class ParameterTreeTestFixture(object):
     def get_accessor_param(self):
         return self.accessor_params
 
-    # def branch_callback(self, path, value):
-    #     self.branch_callback_count += 1
-    #     # print("branch_callback call #{}: on path {} with value {}".format(
-    #     #     self.branch_callback_count, path, value))
-
     def setup(self):
-        TestParameterTree.branch_callback_count = 0
         pass
 
 
@@ -337,9 +325,9 @@ class TestParameterTree():
         branch_vals = test_param_tree.nested_tree.get('branch/')
         assert branch_vals['branch'] == test_param_tree.nested_dict['branch']
 
-    def test_callback_with_extra_branch_paths(self, test_param_tree):
+    def test_set_with_extra_branch_paths(self, test_param_tree):
         """
-        Test that modifiying a branch in a callback tree with extra parameters raises an error.
+        Test that modifiying a branch in a tree with extra parameters raises an error.
         """
         branch_data = deepcopy(test_param_tree.nested_dict['branch'])
         branch_data['extraParam'] = 'oops'

--- a/tests/adapters/test_parameter_tree.py
+++ b/tests/adapters/test_parameter_tree.py
@@ -528,6 +528,7 @@ def test_rw_tree():
     test_rw_tree = RwParameterTreeTestFixture()
     yield test_rw_tree
 
+
 class TestRwParameterTree():
     """Class to test behaviour of read-write parameter trees."""
 
@@ -916,9 +917,35 @@ class TestParamTreeMutable():
         val = test_tree_mutable.param_tree.get('nest/list')
         assert '3' not in val['list']
 
-    def test_mustable_delete_from_dict_in_list(self, test_tree_mutable):
+    def test_mutable_delete_from_dict_in_list(self, test_tree_mutable):
         path = 'nest/list/2/list_test'
 
         test_tree_mutable.param_tree.delete(path)
         val = test_tree_mutable.param_tree.get('nest/list')
         assert {'list_test': "test"} not in val['list']
+
+    def test_mutable_nested_tree_in_immutable_tree(self, test_tree_mutable):
+
+        new_tree = ParameterTree({
+            'immutable_param': "Hello",
+            "tree": test_tree_mutable.param_tree
+        })
+
+        new_node = {"new": 65}
+        path = 'tree/extra'
+        new_tree.set(path, new_node)
+        val = new_tree.get(path)
+        assert val['extra'] == new_node
+
+    def test_mutable_nested_tree_external_change(self, test_tree_mutable):
+
+        new_tree = ParameterTree({
+            'immutable_param': "Hello",
+            "tree": test_tree_mutable.param_tree
+        })
+
+        new_node = {"new": 65}
+        path = 'tree/extra'
+        test_tree_mutable.param_tree.set('extra', new_node)
+        val = new_tree.get(path)
+        assert val['extra'] == new_node

--- a/tests/adapters/test_parameter_tree.py
+++ b/tests/adapters/test_parameter_tree.py
@@ -951,3 +951,39 @@ class TestParamTreeMutable():
         test_tree_mutable.param_tree.set('extra', new_node)
         val = new_tree.get(path)
         assert val['extra'] == new_node
+
+    def test_mutable_nested_tree_delete(self, test_tree_mutable):
+
+        new_tree = ParameterTree({
+            'immutable_param': "Hello",
+            "tree": test_tree_mutable.param_tree
+        })
+
+        path = 'tree/bonus'
+        new_tree.delete(path)
+
+        tree = new_tree.get('')
+
+        assert 'bonus' not in tree['tree']
+
+        with pytest.raises(ParameterTreeError) as excinfo:
+            test_tree_mutable.param_tree.get(path)
+
+        assert "Invalid path" in str(excinfo.value)
+
+    def test_mutable_nested_tree_root_tree_not_affected(self, test_tree_mutable):
+
+        new_tree = ParameterTree({
+            'immutable_param': "Hello",
+            "nest": {
+                "tree": test_tree_mutable.param_tree
+            }
+        })
+
+        new_node = {"new": 65}
+        path = 'immutable_param'
+
+        with pytest.raises(ParameterTreeError) as excinfo:
+            new_tree.set(path, new_node)
+
+        assert "Type mismatch" in str(excinfo.value)


### PR DESCRIPTION
Created a Mutable Flag for Parameter Tree. Setting this flag allows the creation and deletion of nodes in the parameter tree. This includes branch nodes and leaf nodes. Care should be taken when using a Mutable Parameter Tree to avoid overwriting Accessors and other nodes accidentally.

This change also removed the (long depreciated) Callback system from Parameter Tree