### PR TITLE
Add HTTPS support to odin-control

### DIFF
--- a/.github/workflows/test_odin_control.yml
+++ b/.github/workflows/test_odin_control.yml
@@ -12,9 +12,9 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/src/odin/main.py
+++ b/src/odin/main.py
@@ -35,8 +35,13 @@ def main(argv=None):
     config = ConfigParser()
 
     # Define configuration options and add to the configuration parser
-    config.define('http_addr', default='0.0.0.0', option_help='Set HTTP server address')
+    config.define('http_addr', default='0.0.0.0', option_help='Set HTTP/S server address')
     config.define('http_port', default=8888, option_help='Set HTTP server port')
+    config.define('enable_http', default=True, option_help='Enable HTTP')
+    config.define('https_port', default=8443, option_help='Set HTTPS server port')
+    config.define('enable_https', default=False, option_help='Enable HTTPS')
+    config.define('ssl_cert_file', default='cert.pem', option_help='Set SSL certificate file for HTTPS')
+    config.define('ssl_key_file', default='key.pem', option_help='Set SSL key file for HTTPS')
     config.define('debug_mode', default=False, option_help='Enable tornado debug mode')
     config.define('access_logging', default=None, option_help="Set the tornado access log level",
                   metavar="debug|info|warning|error|none")
@@ -65,9 +70,6 @@ def main(argv=None):
 
     # Launch the HTTP server with the parsed configuration
     http_server = HttpServer(config)
-    http_server.listen(config.http_port, config.http_addr)
-
-    logging.info('HTTP server listening on %s:%s', config.http_addr, config.http_port)
 
     # Register a SIGINT signal handler only if this is the main thread
     if isinstance(threading.current_thread(), threading._MainThread):  # pragma: no cover

--- a/tests/config/test_adapter_communication.cfg
+++ b/tests/config/test_adapter_communication.cfg
@@ -1,7 +1,7 @@
 [server]
 debug_mode = 1
 http_port  = 8889
-http_addr  = 0.0.0.0
+http_addr  = 127.0.0.1
 static_path = static
 adapters   = iacDummy, iacTarget1, system_info
 

--- a/tests/config/test_https.cfg
+++ b/tests/config/test_https.cfg
@@ -2,6 +2,10 @@
 debug_mode = 1
 http_port  = 8888
 http_addr  = 127.0.0.1
+enable_https = true
+https_port = 8443
+ssl_cert_file = ./config/ssl_cert.pem
+ssl_key_file = ./config/ssl_key.pem
 static_path = ./static
 adapters   = dummy
 

--- a/tests/config/test_system_info.cfg
+++ b/tests/config/test_system_info.cfg
@@ -1,7 +1,7 @@
 [server]
 debug_mode = 1
 http_port  = 8888
-http_addr  = 0.0.0.0
+http_addr  = 127.0.0.1
 static_path = static
 adapters   = system_info
 

--- a/tests/config/test_system_status.cfg
+++ b/tests/config/test_system_status.cfg
@@ -1,7 +1,7 @@
 [server]
 debug_mode = 1
 http_port  = 8888
-http_addr  = 0.0.0.0
+http_addr  = 127.0.0.1
 static_path = ./static
 adapters   = status
 

--- a/tests/ssl_utils.py
+++ b/tests/ssl_utils.py
@@ -1,0 +1,84 @@
+"""
+Utility class to generate temporary SSL certificate and key files for testing HTTPS support in
+odin_control.
+
+NOTE: THIS IS A SELF-SIGNED CERTIFICATE and KEY FOR TESTING ONLY. DO NOT USE IN PRODUCTION
+
+Tim Nicholls, STFC Detector Systems Software Group
+"""
+
+from tempfile import NamedTemporaryFile
+
+
+class SslTestCert:
+    SSL_CERTIFICATE = """-----BEGIN CERTIFICATE-----
+MIID0zCCArugAwIBAgIUfB/44KsQus8pZWBZep6LeE9v8k4wDQYJKoZIhvcNAQEL
+BQAwazELMAkGA1UEBhMCVUsxFDASBgNVBAgMC094Zm9yZHNoaXJlMQ8wDQYDVQQH
+DAZEaWRjb3QxEjAQBgNVBAoMCVVLUkkgU1RGQzENMAsGA1UECwwEVGVjaDESMBAG
+A1UEAwwJbG9jYWxob3N0MB4XDTIzMDkyNjA5Mzk0OVoXDTMzMDkyMzA5Mzk0OVow
+azELMAkGA1UEBhMCVUsxFDASBgNVBAgMC094Zm9yZHNoaXJlMQ8wDQYDVQQHDAZE
+aWRjb3QxEjAQBgNVBAoMCVVLUkkgU1RGQzENMAsGA1UECwwEVGVjaDESMBAGA1UE
+AwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAus5Y
+wSgq9jx42uXxcvAVGh6jn/YYJwr51sks9rtTpcKe5GoNpA2i8OKeQB6Uwwb2jroK
+y9L2neLqVyRruAoiccKGvbSQCeiyS45c02pQmHAvdbNNmPUEOfRszxorhV/EWw5V
+obxGft9RucZN/l+8FiFwFLIS/TqtTnCTeWRre0Zvl5mzXAISZ7cT5AQ7bUCAYnoh
+tACwHI1b3g+bnNRxMkl3VE7IjyKlP0MuXoamp0yNJofJhKu9x6HRo/UyQVae7Zy9
+9imOuWq/WGuIysprIXQXbwAzBV43oIgYb/ifWbDQGGIEeQRsWWkMduBpC5EtN9uM
+YKA+hXLOfc3zRvUkDQIDAQABo28wbTAdBgNVHQ4EFgQUl6nAO+KZcHkrZ0lCaNwx
+B8nP3LwwHwYDVR0jBBgwFoAUl6nAO+KZcHkrZ0lCaNwxB8nP3LwwDwYDVR0TAQH/
+BAUwAwEB/zAaBgNVHREEEzARgglsb2NhbGhvc3SHBH8AAAEwDQYJKoZIhvcNAQEL
+BQADggEBADUfh6l6lX0o37T9txtb/CQz5uGHndghPn1QtVFBc9ma6U/5FYDH4PqU
+vRf/pKte+BdbyvbjF4e8HRH5/9jB259yOtve+zj6j1nU1vkiAuu16wLT9CHhI5ev
+z4xH0VobE+9gc8iQCzHzp2svo567jQO5UvOIJlYLUkf4Ugq+cxcYTk/XpO04nqLu
+j2DnwtpXUGtE+22dI7oj/QhUI5G8A0mepYg49k7s56vg4VWujsBlnV58H6JWUFjN
+2D2AX+UKRiW19Esjek95Lj1jXEoPHWAUI3lK3/ZDe9L2BZemNdA5apCNA0o7/bvK
+vYiNxUyKe/Y4AYpMfz1FQsixdHMj/gY=
+-----END CERTIFICATE-----
+"""
+
+    SSL_KEY = """-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC6zljBKCr2PHja
+5fFy8BUaHqOf9hgnCvnWySz2u1Olwp7kag2kDaLw4p5AHpTDBvaOugrL0vad4upX
+JGu4CiJxwoa9tJAJ6LJLjlzTalCYcC91s02Y9QQ59GzPGiuFX8RbDlWhvEZ+31G5
+xk3+X7wWIXAUshL9Oq1OcJN5ZGt7Rm+XmbNcAhJntxPkBDttQIBieiG0ALAcjVve
+D5uc1HEySXdUTsiPIqU/Qy5ehqanTI0mh8mEq73HodGj9TJBVp7tnL32KY65ar9Y
+a4jKymshdBdvADMFXjegiBhv+J9ZsNAYYgR5BGxZaQx24GkLkS0324xgoD6Fcs59
+zfNG9SQNAgMBAAECggEAJpivUFtxAvbMHqgvWqjdp0uo0Ypag6iaJcVjn6flOMSt
+KTL7VgfGQICGI2feIyyLYUJxrBrOvyDs+6vIANrBMqF3TvdhYla8je1gYwMem1xk
+hexRzlZjdOj6WVEGKHS4wHqF+ViJ9TlFbL2bDEFx/l2Sx4ficgU/XQtYARcdOPch
+uTc6dukTKHchEgQVHFRMhOBYuHihufBIaoffzy9TNxJ7bUBhDvgBi8B38SfAE71o
+PFTqN4ACx7NCVcisj2WmuOeHvp74GjyIEATyRW57cjCVgAYKU8ddijBqyWs3hPEt
+A83h9jqxkLMkohqs6uldeDJRH/DUn7TYDonGYccdIQKBgQD5yBvibVlVSB6wwV7i
+QoR018tqQDadAvyCiOjZvsNAdxl/EPx2BPbo785IeKeC1dRI0AfLl1BvQnZmDXX7
+DXWvzCw6jexrU5DyJm++opvawz/myrxNb/UA+IecK645Srm00taN3SsimqiWAe2e
+j/ElhdvB6s7CDO/8ee2qPffVIQKBgQC/dOLIzglI/3f9xzDCC1kGCqFzyW0oaQNQ
+DkNSiMQUb4z1XHmND6LDGPIo/OZtsECfZMQvPqvdOjPH3eKrFvewl/XkPrtLB7mq
+UoZwpQNB8DffgUY9PoZ6gPZICtXloLFkUKFbJVbGbUI8Zs93Act/ONEBwoQBABhi
+ePt/Qs3FbQKBgQCE+QPnOcFqBjfYb0kc+L5dGZh/2ul4EuPsdghICycUxZK8M4XD
+KodroGZX7Gt42m7lyGGt/8LhSCeR0q6xVQwG55HQJkfrJxSt5MpuWVDRWEpHijxO
+mUB8INLIz/QzKdXNLsTrxwc0p9MB8MrYM9bz29wO0vr5ETwdU6ezjsPGIQKBgGaS
+UZmxQKo6K+frWoTrHXOuKFdnF7Mpp5uxOII0QZCNPuCI/ZoEQXfymnI5I56qacS7
+cJu7IMpyDyHKD1EICgUzNIpmzWLiLadBdUNONJOUBesZUC8pm1RwWQG5xGS0lbUf
+uYKiW34NNQo1LnscnBB5uQgPVTdP/MBs/phsit91AoGANLq/iPBhoGIvLA4Bok2v
+diGjDII7NV55JnTVmO3tQc0C7EPdOIVPWg1MimIlsoxZ8OoJInBt0By7iuFLys6A
+PBZ1ELX+HaxrA7MJr4gq4uAMpdfIdlXAmTLFBsSLGNw4b0YTbkGBIDzVMmn4bmA8
+c7psJdd5G7B1rHg1lQ548EY=
+-----END PRIVATE KEY-----
+"""
+
+    def __init__(self):
+        self._cert_file = NamedTemporaryFile(mode="w+")
+        self._cert_file.write(self.SSL_CERTIFICATE)
+        self._cert_file.flush()
+
+        self._key_file = NamedTemporaryFile(mode="w+")
+        self._key_file.write(self.SSL_KEY)
+        self._key_file.flush()
+
+    @property
+    def cert_file(self):
+        return self._cert_file.name
+
+    @property
+    def key_file(self):
+        return self._key_file.name

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -57,8 +57,10 @@ class OdinTestServer(object):
 
         parser.add_section('server')
         parser.set('server', 'debug_mode', '1')
+        parser.set('server', 'enable_http', 'true')
         parser.set('server', 'http_port', str(server_port))
         parser.set('server', 'http_addr', self.server_addr)
+        parser.set('server', 'enable_https', 'false')
         parser.set('server', 'static_path', static_path)
 
         if adapter_config is not None:


### PR DESCRIPTION
This PR adds support for serving HTTPS requests to odin-control. This is disabled by default (preserving the standard HTTP-only behaviour) and can be configured by the following options:

- `enable_https`: enable HTTPS (default: false)
- `https_port`: set the HTTPS port to listen on (default: 8443)
- `ssl_cert_file`: set the SSL certificate file to use (default: `cert.pem`)
- `ssl_key_file`: set the SSL private key file to use (default: `key.pem`)

An additional option allows HTTP serving to be enabled or disabled:
- `enable_http`: enable HTTP (default: true)

The SSL certificate and private keys are the standard X.509 PEM format and can be generated with the usual tools (e.g. openSSL). Self-signed certificates can be used but are typically deprecated by browsers; tools such as [mkcert](https://mkcert.dev/) can be used to generate a signed certificate and local CA for development/testing.

This PR also updates all test configuration files to default to the HTTP/HTTPS listen address to loopback (127.0.0.1) only.
