### PR TITLE
Updated ParameterTree to accept a partial list update

### DIFF
--- a/src/odin/adapters/base_parameter_tree.py
+++ b/src/odin/adapters/base_parameter_tree.py
@@ -495,6 +495,15 @@ class BaseParameterTree(object):
                 raise ParameterTreeError(
                     'Invalid path: {}{} {}'.format(cur_path, str(i), str(index_error))
                 )
+        if isinstance(node, list) and isinstance(new_data, list):
+            try:
+                for i, val in enumerate(new_data):
+                    node[i] = self._merge_tree(node[i], val, cur_path + str(i) + '/')
+                return node
+            except IndexError as index_error:
+                raise ParameterTreeError(
+                    'Invalid path: {}{} {}'.format(cur_path, str(i), str(index_error))
+                )
 
         # Update the value of the current parameter, calling the set accessor if specified and
         # validating the type if necessary.

--- a/src/odin/adapters/base_parameter_tree.py
+++ b/src/odin/adapters/base_parameter_tree.py
@@ -486,16 +486,7 @@ class BaseParameterTree(object):
                 raise ParameterTreeError(
                     'Invalid path: {}{}'.format(cur_path, str(key_error)[1:-1])
                 )
-        if isinstance(node, list) and isinstance(new_data, dict):
-            try:
-                for i, val in enumerate(new_data):
-                    node[i] = self._merge_tree(node[i], val, cur_path + str(i) + '/')
-                return node
-            except IndexError as index_error:
-                raise ParameterTreeError(
-                    'Invalid path: {}{} {}'.format(cur_path, str(i), str(index_error))
-                )
-        if isinstance(node, list) and isinstance(new_data, list):
+        if isinstance(node, list) and isinstance(new_data, (dict, list)):
             try:
                 for i, val in enumerate(new_data):
                     node[i] = self._merge_tree(node[i], val, cur_path + str(i) + '/')

--- a/tests/adapters/test_parameter_tree.py
+++ b/tests/adapters/test_parameter_tree.py
@@ -441,6 +441,40 @@ class TestParameterTree():
         test_param_tree.list_tree.set("",tree_data)
         assert test_param_tree.list_tree.get("main") == tree_data
 
+    def test_list_tree_set_partial_from_root(self, test_param_tree):
+        """Test that it is possible to set part of a list tree from its root."""
+        tree_data = {
+            'main' : [
+                {
+                    'intParam': 3,
+                    'floatParam': 4.56,
+                    'boolParam': True,
+                    'strParam':  "test1",
+                },
+                [1,2,3,4]
+            ]
+        }
+        test_param_tree.list_tree.set("",tree_data)
+        assert test_param_tree.list_tree.get("main/0/intParam") == {'intParam': 3}
+        assert test_param_tree.list_tree.get("main/0/floatParam") == {'floatParam': 4.56}
+        assert test_param_tree.list_tree.get("main/0/boolParam") == {'boolParam': True}
+        assert test_param_tree.list_tree.get("main/0/strParam") == {'strParam': "test1"}
+        assert test_param_tree.list_tree.get("main/1") == {'1': [1,2,3,4]}
+
+        tree_data = {
+            'main' : [
+                {
+                    'intParam': 6,
+                },
+            ]
+        }
+        test_param_tree.list_tree.set("",tree_data)
+        assert test_param_tree.list_tree.get("main/0/intParam") == {'intParam': 6}
+        assert test_param_tree.list_tree.get("main/0/floatParam") == {'floatParam': 4.56}
+        assert test_param_tree.list_tree.get("main/0/boolParam") == {'boolParam': True}
+        assert test_param_tree.list_tree.get("main/0/strParam") == {'strParam': "test1"}
+        assert test_param_tree.list_tree.get("main/1") == {'1': [1,2,3,4]}
+
     def test_list_tree_from_dict(self, test_param_tree):
         """TEet that a list tree can be set with a dict of index/values."""
         new_list_param = {0: 0, 1: 1, 2: 2, 3: 3}


### PR DESCRIPTION
I noticed while testing that if I tried to update (calling set) a subset of items contained within a list in a complex ParameterTree then the rest of the items below that point would be removed from the ParameterTree.
I think there is a check missing in the merge tree method where the existing part of the tree is a type list and the incoming change at the same level is also a type list.

I have written a unit test to demonstrate the problem, and with my proposed update the unit test passes along with all of the others.  It is possible that I have misunderstood the mechanism for setting, we might need to discuss this change further.