### PR TITLE
Improve odin-control shutdown and reload

### DIFF
--- a/src/odin/main.py
+++ b/src/odin/main.py
@@ -11,17 +11,13 @@ import signal
 import threading
 
 import tornado.ioloop
+from tornado.autoreload import add_reload_hook
 
 from odin.http.server import HttpServer
 from odin.config.parser import ConfigParser, ConfigError
 from odin.logconfig import add_graylog_handler
 
-
-def shutdown_handler():  # pragma: no cover
-    """Handle interrupt signals gracefully and shutdown IOLoop."""
-    logging.info('Interrupt signal received, shutting down')
-    tornado.ioloop.IOLoop.instance().stop()
-
+_stop_ioloop = False  # Global variable to indicate ioloop should be shut down
 
 def main(argv=None):
     """Run the odin-control server.
@@ -68,15 +64,66 @@ def main(argv=None):
             config.graylog_static_fields
         )
 
+     # Get the Tornado ioloop instance
+    ioloop = tornado.ioloop.IOLoop.instance()
+
     # Launch the HTTP server with the parsed configuration
     http_server = HttpServer(config)
 
-    # Register a SIGINT signal handler only if this is the main thread
-    if isinstance(threading.current_thread(), threading._MainThread):  # pragma: no cover
-        signal.signal(signal.SIGINT, lambda signum, frame: shutdown_handler())
+    # If debug mode is enabled, add an autoreload hook to the server to ensure that adapter cleanup
+    # methods are called as the server reloads
+    if config.debug_mode:
+        add_reload_hook(http_server.cleanup_adapters)
 
-    # Enter IO processing loop
-    tornado.ioloop.IOLoop.instance().start()
+    def shutdown_handler(sig_name):  # pragma: no cover
+        """Shut down the running server cleanly.
+
+        This inner function implements a signal handler to shut down the running server cleanly in
+        response to a signal. The underlying HTTP server is stopped, preventing new connections
+        from being accepted, and a global flag set true to allow a periodic task to terminate the
+        ioloop cleanly.
+
+        :param signum: signal number that the handler was invoked with
+        :param _: unused stack frame
+        """
+        global _stop_ioloop
+        logging.info('%s signal received, shutting down', sig_name)
+
+        # Stop the HTTP server
+        http_server.stop()
+
+        # Tell the periodic callback to stop the ioloop when next invokved
+        _stop_ioloop = True
+
+    def stop_ioloop():  # pragma: no cover
+        """Stop the running ioloop cleanly.
+
+        This inner function is run as a periodic callback and stops the ioloop when requested by
+        the signal handler. This mechansim is necessary to ensure that the ioloop stops cleanly
+        under all conditions, for instance when adapters and handlers have not been correctly
+        initialised.
+        """
+        global _stop_ioloop
+        if _stop_ioloop:
+             logging.debug("Stopping ioloop")
+
+             # Stop the ioloop
+             ioloop.stop()
+
+    # Register a shutdown signal handler and start an ioloop stop callback only if this is the
+    # main thread
+    if isinstance(threading.current_thread(), threading._MainThread):  # pragma: no cover
+        signal.signal(signal.SIGINT, lambda signum, frame: shutdown_handler('Interrupt'))
+        signal.signal(signal.SIGTERM, lambda signum, frame: shutdown_handler('Terminate'))
+        tornado.ioloop.PeriodicCallback(stop_ioloop, 1000).start()
+
+    # Start the ioloop
+    ioloop.start()
+
+    # If the application isn't shutting down due to the signal handler being invoked (e.g. when
+    # running in a secondary thread), ensure the HTTP server stops cleanly
+    if not _stop_ioloop:
+        http_server.stop()
 
     # At shutdown, clean up the state of the loaded adapters
     http_server.cleanup_adapters()

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
     pytest-cov
     requests
     py27: mock
-    py{36,37,38,39}: pytest-asyncio
+    py{36,37,38,39}: pytest-asyncio<0.22
     tornado4: tornado>=4.0,<5.0
     tornado5: tornado>=5.0,<6.0
     tornado6: tornado>=6.0


### PR DESCRIPTION
This PR improves the shutdown/reload mechanism in odin-control, improving a number of behaviours:

-  startup/shutdown scripts on some systems send SIGTERM to the running process - this didn't invoke the adapter cleanup mechanism. SIGTERM is now also managed by the shutdown signal handler
- the Tornado debug mode / autoreload mechanism also didn't call adapter cleanup before reloading the server. The cleanup adapter method is now registered as a Tornado autoreload hook.
- a misconfigured odin_control instance due to an e.g. malformed config file or bad command line arguments, didn't terminate cleanly from a SIGTERM or SIGINT (e.g. ctrl-C at the command line). This was due to the main ioloop having nothing scheduled on it to allow the stop mechanism to work correctly. This has been resolved by adding a periodic callback to the ioloop that runs unconditionally and will shutdown the loop on demand.