### PR TITLE
Switch sync proxy adapter to use requests package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,10 +32,12 @@ dev =
     mock;python_version<'3'
     requests
     tox
-    pytest-asyncio
+    pytest-asyncio<0.23
     pytest-cov
 graylog =
     pygelf
+sync_proxy =
+    requests
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
This PR restores functionality to the synchronous proxy adapter, which was broken by removal of the synchronous HttpClient from tornado. The sync proxy adapter now uses the requests package instead. The proxy adapter implementation more widely has been refactored to better isolate the client implementation and avoid making requests a required dependency of odin-control.

The dev requirements for installing odin-control now also pin the pytest-asyncio version to <0.23 to avoid breaking changes with async fixture scope (which still seem unfixed in the package).