### PR TITLE
Adding Parameter Tree replace method

### DIFF
--- a/src/odin/adapters/base_parameter_tree.py
+++ b/src/odin/adapters/base_parameter_tree.py
@@ -265,7 +265,7 @@ class BaseParameterTree(object):
         # Return the populated tree at the appropriate path
         return self._populate_tree({levels[-1]: subtree}, with_metadata)
 
-    def set(self, path, data):
+    def set(self, path, data, replace=False):
         """Set the values of the parameters in a tree.
 
         This method sets the values of parameters in a tree, based on the data passed to it
@@ -274,6 +274,7 @@ class BaseParameterTree(object):
 
         :param path: path to set parameters for in the tree
         :param data: nested dictionary representing values to update at the path
+        :param replace: if set to true then the structure is replaced rather than merged
         """
         # Expand out any lists/tuples
         data = self._build_tree(data)
@@ -304,7 +305,12 @@ class BaseParameterTree(object):
             path += '/'
 
         # Merge data with tree
-        merged = self._merge_tree(merge_child, data, path)
+        if replace:
+            if not self.mutable:
+                raise ParameterTreeError("Invalid Replace Attempt: Tree Not Mutable")
+            merged = data
+        else:
+            merged = self._merge_tree(merge_child, data, path)
 
         # Add merged part to tree, either at the top of the tree or at the
         # appropriate level speicfied by the path
@@ -315,6 +321,18 @@ class BaseParameterTree(object):
             merge_parent[levels[-1]] = merged
         else:
             merge_parent[int(levels[-1])] = merged
+
+    def replace(self, path, data):
+        """Replaces a branch of parameters in a tree.
+
+        This method sets the values of parameters in a tree, based on the data passed to it
+        as a nested dictionary of parameter and value pairs. Any structure below the insertion
+        point in the exising tree is replaced with this new structure.
+
+        :param path: path to set parameters for in the tree
+        :param data: nested dictionary representing structure to replace at the path
+        """
+        self.set(path, data, replace=True)
 
     def delete(self, path=''):
         """

--- a/tests/adapters/test_parameter_tree.py
+++ b/tests/adapters/test_parameter_tree.py
@@ -257,11 +257,6 @@ class ParameterTreeTestFixture(object):
             'branch': self.complex_tree_branch,
         })
 
-        self.complex_list_tree = ParameterTree({
-            'main' : [
-
-            ]
-        })
         self.list_tree = ParameterTree({
             'main' : [
                 self.simple_dict.copy(),
@@ -892,6 +887,18 @@ class TestParamTreeMutable():
         assert "Type mismatch setting" in str(excinfo.value)
         # val = test_tree_mutable.param_tree.get(path)
         # assert val['write'] == new_node
+
+    def test_mutable_replace_branch(self, test_tree_mutable):
+        """
+        Test that using the replace method completely replaces the branch
+        rather than merging in a dictionary.
+        """
+        new_node = {"double_nest": 294}
+        path = 'nest'
+
+        test_tree_mutable.param_tree.replace(path, new_node)
+        val = test_tree_mutable.param_tree.get(path)
+        assert val[path] == new_node
 
     def test_mutable_put_replace_nested_path(self, test_tree_mutable):
 

--- a/tests/adapters/test_parameter_tree.py
+++ b/tests/adapters/test_parameter_tree.py
@@ -257,6 +257,11 @@ class ParameterTreeTestFixture(object):
             'branch': self.complex_tree_branch,
         })
 
+        self.complex_list_tree = ParameterTree({
+            'main' : [
+
+            ]
+        })
         self.list_tree = ParameterTree({
             'main' : [
                 self.simple_dict.copy(),


### PR DESCRIPTION
This provides the option of replacing a branch of a parameter tree.  Currently only the set exists which will merge rather than replace.  The use case for replace is where FrameProcessor plugins might change, or the FrameProcessor itself is reloaded with a different set of plugins.