### PR TITLE
Remove the deprecated odin_server entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ graylog = [
 
 [project.scripts]
 odin_control = "odin_control.main:main"
-odin_server = "odin_control.main:main_deprecate"
 
 [project.urls]
 GitHub = "https://github.com/odin-detector/odin-control"

--- a/src/odin_control/main.py
+++ b/src/odin_control/main.py
@@ -146,27 +146,5 @@ def main(argv=None):
     return 0
 
 
-def main_deprecate(argv=None):  # pragma: no cover
-    """Deprecated main entry point for running the odin control server.
-
-    This method adds an entry point for running odin control server that is run by the
-    deprecated odin_server command. It simply runs the main entry point as normal having
-    printing a deprecation warning.
-    """
-    import warnings
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("always", DeprecationWarning)
-        message = """
-
-The odin_server script entry point is deprecated and will be removed in future releases. Consider
-using \'odin_control\' instead
-
-            """
-        warnings.warn(message, DeprecationWarning, stacklevel=1)
-
-    main(argv)
-
-
 if __name__ == "__main__":  # pragma: no cover
     sys.exit(main())


### PR DESCRIPTION
This PR addresses #67 and removes the long-deprecated `odin_server` script entry point from the package.

Requires upstream PR #70 to be merged first